### PR TITLE
CFY-972 updated import links to point to 3.1/1.1 versions; added types.y...

### DIFF
--- a/blueprint.yaml
+++ b/blueprint.yaml
@@ -1,6 +1,7 @@
 imports:
-    - http://www.getcloudify.org/spec/bash-plugin/1.0/plugin.yaml
-    - http://www.getcloudify.org/spec/openstack-plugin/1.0/plugin.yaml
+    - http://www.getcloudify.org/spec/cloudify/3.1/types.yaml
+    - http://www.getcloudify.org/spec/openstack-plugin/1.1/plugin.yaml
+    - http://www.getcloudify.org/spec/bash-plugin/1.1/plugin.yaml
 
 plugins:
     nodecellar_config_plugin:


### PR DESCRIPTION
...aml import since plugins no longer have it
