### PR TITLE
Update start-mongo.sh

### DIFF
--- a/scripts/mongo/start-mongo.sh
+++ b/scripts/mongo/start-mongo.sh
@@ -57,7 +57,7 @@ PORT=$(ctx node properties port)
 MONGO_ROOT_PATH=$(ctx instance runtime_properties mongo_root_path)
 MONGO_BINARIES_PATH=$(ctx instance runtime_properties mongo_binaries_path)
 MONGO_DATA_PATH=$(ctx instance runtime_properties mongo_data_path)
-COMMAND="${MONGO_BINARIES_PATH}/bin/mongod --port ${PORT} --dbpath ${MONGO_DATA_PATH} --rest --journal --shardsvr"
+COMMAND="${MONGO_BINARIES_PATH}/bin/mongod --port ${PORT} --dbpath ${MONGO_DATA_PATH} --rest --journal --shardsvr --smallFiles"
 
 ctx logger info "${COMMAND}"
 nohup ${COMMAND} > /dev/null 2>&1 &


### PR DESCRIPTION
add the --smallFiles option to the COMMAND. It instructs MongoDB to use a smaller default file size. It makes the install faster and avoid problems with VMs with small volumes disk space,

http://docs.mongodb.org/manual/reference/configuration-options/